### PR TITLE
fix cache key by adding auth hash

### DIFF
--- a/lib/TvmClient.js
+++ b/lib/TvmClient.js
@@ -14,6 +14,8 @@ const joi = require('@hapi/joi')
 const fs = require('fs-extra')
 const fetch = require('node-fetch').default
 const upath = require('upath')
+const crypto = require('crypto')
+
 const tmp = require('os').tmpdir()
 const logger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-core-tvm', { provider: './DebugLogger' })
 const cloneDeep = require('lodash.clonedeep')
@@ -36,6 +38,11 @@ function urlJoin (...args) {
 // eslint-disable-next-line jsdoc/require-jsdoc
 function hideAuth (auth) {
   return auth && '<hidden>'
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+function createCacheKey (url, namespace, auth) {
+  return crypto.createHash('sha256').update(url + namespace + auth, 'binary').digest('hex')
 }
 
 /**
@@ -238,7 +245,7 @@ class TvmClient {
    */
   async _getCredentials (endpoint) {
     const fullUrl = urlJoin(this.apiUrl, endpoint)
-    const cacheKey = `${this.ow.namespace}-${fullUrl}`
+    const cacheKey = createCacheKey(fullUrl, this.ow.namespace, this.ow.auth)
 
     let creds = await this._getCredentialsFromCacheFile(cacheKey)
     if (!creds) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

currently the cache key depends only on the tvm url and namespace.
this may create a security issue where passing a valid namespace for an invalid auth key will still return valid tvm credentials if those are cached.

this is a fix for this issue
<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
