### PR TITLE
fix: resourceUrl.startsWith error, exponentialBackoff takes a string

### DIFF
--- a/lib/TvmClient.js
+++ b/lib/TvmClient.js
@@ -221,7 +221,7 @@ class TvmClient {
     // add query params
     Object.keys(params).forEach(k => fullUrl.searchParams.append(k, params[k]))
 
-    const response = await retryRequest.exponentialBackoff(fullUrl,
+    const response = await retryRequest.exponentialBackoff(fullUrl.toString(),
       {
         headers: {
           Authorization: `Basic ${Buffer.from(this.ow.auth).toString('base64')}`,

--- a/test/TvmClient.test.js
+++ b/test/TvmClient.test.js
@@ -361,7 +361,7 @@ describe('getAzureBlobCredentials', () => {
       await expect(tvmClient.getAzureBlobCredentials.bind(tvmClient)).toThrowStatusError(500)
       expect(mockExponentialBackoff).toHaveBeenCalledTimes(1)
       expect(mockExponentialBackoff).toHaveBeenCalledWith(
-        new URL(TvmClient.DefaultApiHost + '/' + TvmClient.AzureBlobEndpoint + '/' + fakeTVMInput.ow.namespace),
+        TvmClient.DefaultApiHost + '/' + TvmClient.AzureBlobEndpoint + '/' + fakeTVMInput.ow.namespace,
         expect.objectContaining({ headers: { Authorization: fakeAuthBase64Header, 'x-Api-Key': ADOBE_IO_GW_API_KEY } }),
         {}
       )
@@ -379,7 +379,7 @@ describe('getAzureBlobCredentials', () => {
       await expect(tvmClient.getAzureBlobCredentials.bind(tvmClient)).toThrowStatusError(500)
       expect(mockExponentialBackoff).toHaveBeenCalledTimes(1)
       expect(mockExponentialBackoff).toHaveBeenCalledWith(
-        new URL(TvmClient.DefaultApiHost + '/' + TvmClient.AzureBlobEndpoint + '/' + fakeTVMInput.ow.namespace),
+        TvmClient.DefaultApiHost + '/' + TvmClient.AzureBlobEndpoint + '/' + fakeTVMInput.ow.namespace,
         expect.objectContaining({ headers: { Authorization: fakeAuthBase64Header, 'x-Api-Key': ADOBE_IO_GW_API_KEY } }),
         { maxRetries: 2 }
       )
@@ -397,7 +397,7 @@ describe('getAzureBlobCredentials', () => {
       await expect(tvmClient.getAzureBlobCredentials.bind(tvmClient)).toThrowStatusError(500)
       expect(mockExponentialBackoff).toHaveBeenCalledTimes(1)
       expect(mockExponentialBackoff).toHaveBeenCalledWith(
-        new URL(TvmClient.DefaultApiHost + '/' + TvmClient.AzureBlobEndpoint + '/' + fakeTVMInput.ow.namespace),
+        TvmClient.DefaultApiHost + '/' + TvmClient.AzureBlobEndpoint + '/' + fakeTVMInput.ow.namespace,
         expect.objectContaining({ headers: { Authorization: fakeAuthBase64Header, 'x-Api-Key': ADOBE_IO_GW_API_KEY } }),
         { initialDelayInMillis: 50 }
       )

--- a/test/TvmClient.test.js
+++ b/test/TvmClient.test.js
@@ -230,7 +230,7 @@ describe('getAzurePresignCredentials', () => {
     const creds = await tvmClient.getAzureBlobPresignCredentials(options)
     expect(creds).toEqual(fakeAzureTVMPresignResponse)
     // calls with namespace as path arg
-    expect(mockExponentialBackoff.mock.calls[0][0].toString()).toEqual(TvmClient.DefaultApiHost + '/' +
+    expect(mockExponentialBackoff.mock.calls[0][0]).toEqual(TvmClient.DefaultApiHost + '/' +
       TvmClient.AzurePresignEndpoint + '/' + fakeTVMInput.ow.namespace + '?blobName=fakefile&expiryInSeconds=60&permissions=fake')
     // adds Authorization header
     expect(mockExponentialBackoff.mock.calls[0][1].headers).toEqual({ Authorization: fakeAuthBase64Header, 'x-Api-Key': ADOBE_IO_GW_API_KEY })
@@ -293,7 +293,7 @@ describe('revokePresignURLs', () => {
     const creds = await tvmClient.revokePresignURLs()
     expect(creds).toEqual(fakeAzureTVMPresignResponse)
     // calls with namespace as path arg
-    expect(mockExponentialBackoff.mock.calls[0][0].toString()).toEqual(TvmClient.DefaultApiHost + '/' +
+    expect(mockExponentialBackoff.mock.calls[0][0]).toEqual(TvmClient.DefaultApiHost + '/' +
       TvmClient.AzureRevokePresignEndpoint + '/' + fakeTVMInput.ow.namespace)
     // adds Authorization header
     expect(mockExponentialBackoff.mock.calls[0][1].headers).toEqual(expect.objectContaining({ Authorization: 'Basic ZmFrZWF1dGg=', 'x-Api-Key': 'firefly-aio-tvm' }))
@@ -335,7 +335,7 @@ describe('getAzureBlobCredentials', () => {
       const creds = await tvmClient.getAzureBlobCredentials()
       expect(creds).toEqual(fakeAzureTVMResponse)
       // calls with namespace as path arg
-      expect(mockExponentialBackoff.mock.calls[0][0].toString()).toEqual(TvmClient.DefaultApiHost + '/' + TvmClient.AzureBlobEndpoint + '/' + fakeTVMInput.ow.namespace)
+      expect(mockExponentialBackoff.mock.calls[0][0]).toEqual(TvmClient.DefaultApiHost + '/' + TvmClient.AzureBlobEndpoint + '/' + fakeTVMInput.ow.namespace)
       // adds Authorization header
       expect(mockExponentialBackoff.mock.calls[0][1].headers).toEqual(expect.objectContaining({ Authorization: fakeAuthBase64Header }))
       expect(fs.readFile).toHaveBeenCalledTimes(0)
@@ -495,7 +495,7 @@ describe('getAwsS3Credentials', () => {
     const tvmClient = await TvmClient.init(fakeTVMInput)
     const creds = await tvmClient.getAwsS3Credentials()
     expect(creds).toEqual(fakeAwsS3Response)
-    expect(mockExponentialBackoff.mock.calls[0][0].toString()).toEqual(TvmClient.DefaultApiHost + '/' + TvmClient.AwsS3Endpoint + '/' + fakeTVMInput.ow.namespace)
+    expect(mockExponentialBackoff.mock.calls[0][0]).toEqual(TvmClient.DefaultApiHost + '/' + TvmClient.AwsS3Endpoint + '/' + fakeTVMInput.ow.namespace)
     expect(mockExponentialBackoff.mock.calls[0][1].headers).toEqual(expect.objectContaining({ Authorization: fakeAuthBase64Header }))
   })
 })
@@ -509,7 +509,7 @@ describe('getAzureCosmosCredentials', () => {
     const tvmClient = await TvmClient.init(fakeTVMInput)
     const creds = await tvmClient.getAzureCosmosCredentials()
     expect(creds).toEqual(fakeAzureCosmosResponse)
-    expect(mockExponentialBackoff.mock.calls[0][0].toString()).toEqual(TvmClient.DefaultApiHost + '/' + TvmClient.AzureCosmosEndpoint + '/' + fakeTVMInput.ow.namespace)
+    expect(mockExponentialBackoff.mock.calls[0][0]).toEqual(TvmClient.DefaultApiHost + '/' + TvmClient.AzureCosmosEndpoint + '/' + fakeTVMInput.ow.namespace)
     expect(mockExponentialBackoff.mock.calls[0][1].headers).toEqual(expect.objectContaining({ Authorization: fakeAuthBase64Header }))
   })
 })


### PR DESCRIPTION
Accompanying PR: https://github.com/adobe/aio-lib-core-networking/pull/91

Users are seeing the following error when using a proxy + trying to deploy web assets: 
```
Error: TypeError: resourceUrl.startsWith is not a function ›       
at proxyAgent (/opt/homebrew/lib/node_modules/@adobe/aio-cli/node_modules/@adobe/aio-lib-core-networking/src/ProxyFetch.js:61:19) ›       
at ProxyFetch.fetch (/opt/homebrew/lib/node_modules/@adobe/aio-cli/node_modules/@adobe/aio-lib-core-networking/src/ProxyFetch.js:115:14)
```

This PR is the real fix, we need to pass a string to the core networking library when using exponential backoff

Tested by locally linking this library 